### PR TITLE
fix: avoid failovers when Pod readiness status is stale

### DIFF
--- a/controllers/replicas.go
+++ b/controllers/replicas.go
@@ -37,7 +37,7 @@ import (
 var ErrWalReceiversRunning = fmt.Errorf("wal receivers are still running")
 
 // updateTargetPrimaryFromPods sets the name of the target primary from the Pods status if needed
-// this function will returns the name of the new primary selected for promotion
+// this function will return the name of the new primary selected for promotion
 func (r *ClusterReconciler) updateTargetPrimaryFromPods(
 	ctx context.Context,
 	cluster *apiv1.Cluster,

--- a/pkg/postgres/status.go
+++ b/pkg/postgres/status.go
@@ -98,6 +98,34 @@ type PgStatReplication struct {
 	SyncPriority    string `json:"syncPriority,omitempty"`
 }
 
+// IsReadinessProbePositive checks if the readiness probe is positive
+// for the Pod corresponding to this instance.
+//
+// This represents the Kubelet point-of-view of the readiness status
+// of this instance, and may be slightly stale when the Kubelet
+// has not still invoked the readiness probe.
+//
+// If you want to check the latest detected status of PostgreSQL
+// you need to use IsPostgresqlReady and not this function.
+func (status PostgresqlStatus) IsReadinessProbePositive() bool {
+	return status.IsReady
+}
+
+// IsPostgresqlReady checks if the instance manager is reporting
+// this instance as ready.
+//
+// This is updated at the moment of the collection of the status
+// of this instance, and is more updated then IsReadinessProbePositive
+func (status PostgresqlStatus) IsPostgresqlReady() bool {
+	// To load the status of this instance we use the `/pg/status` endpoint
+	// of the instance manager. If the status has been collected successfully
+	// then PostgreSQL is ready and running, and the Error field will be nil.
+	//
+	// Otherwise, we didn't manage to collect the status of the PostgreSQL
+	// instance, and we'll have an error inside the Error field
+	return status.Error != nil
+}
+
 // PgStatReplicationList is a list of PgStatReplication reported by the primary instance
 type PgStatReplicationList []PgStatReplication
 
@@ -164,7 +192,8 @@ func (list *PostgresqlStatusList) LogStatus(ctx context.Context) {
 			"isPrimary", item.IsPrimary,
 			"isReady", item.IsReady,
 			"pendingRestart", item.PendingRestart,
-			"pendingRestartForDecrease", item.PendingRestartForDecrease)
+			"pendingRestartForDecrease", item.PendingRestartForDecrease,
+			"statusCollectionError", item.Error)
 	}
 
 	contextLogger.Debug(
@@ -195,15 +224,6 @@ func (list *PostgresqlStatusList) Less(i, j int) bool {
 		return false
 	case list.Items[i].Error == nil && list.Items[j].Error != nil:
 		return true
-	}
-
-	// Non-ready Pods go to the bottom of the list
-	// since we prefer ready Pods as new primary
-	switch {
-	case list.Items[i].IsReady && !list.Items[j].IsReady:
-		return true
-	case !list.Items[i].IsReady && list.Items[j].IsReady:
-		return false
 	}
 
 	// Manage primary servers

--- a/pkg/postgres/status_test.go
+++ b/pkg/postgres/status_test.go
@@ -30,44 +30,41 @@ import (
 )
 
 var _ = Describe("PostgreSQL status", func() {
+	errCannotConnectToPostgres := fmt.Errorf("cannot connect to PostgreSQL")
+
 	list := PostgresqlStatusList{
 		Items: []PostgresqlStatus{
 			{
-				Pod:     corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "server-04"}},
-				Error:   fmt.Errorf("cannot find postgres container"),
-				IsReady: true,
+				Pod:   corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "server-04"}},
+				Error: errCannotConnectToPostgres,
 			},
 			{
 				Pod:         corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "server-06"}},
 				IsPrimary:   false,
 				ReceivedLsn: "1/23",
 				ReplayLsn:   "1/22",
-				IsReady:     false,
+				Error:       errCannotConnectToPostgres,
 			},
 			{
 				Pod:         corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "server-30"}},
 				IsPrimary:   false,
 				ReceivedLsn: "1/23",
 				ReplayLsn:   "1/22",
-				IsReady:     true,
 			},
 			{
 				Pod:         corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "server-20"}},
 				IsPrimary:   false,
 				ReceivedLsn: "1/21",
-				IsReady:     true,
 			},
 			{
 				Pod:       corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "server-10"}},
 				IsPrimary: true,
-				IsReady:   true,
 			},
 			{
 				Pod:         corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "server-40"}},
 				IsPrimary:   false,
 				ReceivedLsn: "1/23",
 				ReplayLsn:   "1/23",
-				IsReady:     true,
 			},
 		},
 	}
@@ -79,12 +76,10 @@ var _ = Describe("PostgreSQL status", func() {
 					Pod:         corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "server-20"}},
 					IsPrimary:   false,
 					ReceivedLsn: "1/21",
-					IsReady:     true,
 				},
 				{
 					Pod:       corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "server-10"}},
 					IsPrimary: true,
-					IsReady:   true,
 				},
 			},
 		}
@@ -100,12 +95,10 @@ var _ = Describe("PostgreSQL status", func() {
 					Pod:         corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "server-20"}},
 					IsPrimary:   false,
 					ReceivedLsn: "1/21",
-					IsReady:     true,
 				},
 				{
 					Pod:       corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "server-10"}},
 					IsPrimary: true,
-					IsReady:   true,
 				},
 			},
 		}
@@ -120,12 +113,10 @@ var _ = Describe("PostgreSQL status", func() {
 				{
 					Pod:       corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "server-20"}},
 					IsPrimary: false,
-					IsReady:   true,
 				},
 				{
 					Pod:       corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "server-10"}},
 					IsPrimary: true,
-					IsReady:   true,
 				},
 			},
 		}


### PR DESCRIPTION
The operator was relying on the readiness status of the Pod to determine if the current primary was healthy of not, but sometimes this will be different from the real PostgreSQL status since it's checked every `periodSeconds` by the Kubelet.

This can happen when lifting fencing from the primary node and the Kubelet still haven't marked the Pod as ready, leading for a failover to happen immediately after the event.

With this patch, we are using the status collected from the instance manager to elect the new primary, and we'll wait for the Kubelet to refresh the readiness probe status when PostgreSQL is up and running but the Pod is still marked as non ready.

Closes: #889 

Signed-off-by: Leonardo Cecchi <leonardo.cecchi@enterprisedb.com>