### PR TITLE
fix: ensure we have a WAL to archive for every newly created cluster

### DIFF
--- a/pkg/management/postgres/initdb.go
+++ b/pkg/management/postgres/initdb.go
@@ -256,6 +256,14 @@ func (info InitInfo) ConfigureNewInstance(instance *Instance) error {
 		return fmt.Errorf("could not create %v file: %w", filePath, err)
 	}
 
+	// We make sure we have a new WAL to archive
+	if _, err := dbSuperUser.Exec("CHECKPOINT"); err != nil {
+		return fmt.Errorf("error while requiring a checkpoint: %w", err)
+	}
+
+	if _, err := dbSuperUser.Exec("SELECT pg_switch_wal()"); err != nil {
+		return fmt.Errorf("error while switching to a new WAL: %w", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
We require WAL archiving to be working before taking every backup, and we control that by checking the archival status of the latest archived WAL.

For this check to be done we need to have WAL to archive, and this is not always true for new clusters.

For PostgreSQL 14 and older, this condition was granted by the `archive_timeout` setting but since PostgreSQL 15 the instance won't mark the first WAL as ready to archive if there is no database activity.

With this patch we always switch to a new WAL after having created a cluster, and we'll always have a WAL to archive even for newly created clusters.

Closes: #896

Signed-off-by: Leonardo Cecchi <leonardo.cecchi@enterprisedb.com>